### PR TITLE
Update yum example

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@ Sigil, from the Latin sigillum, meaning a "little sign", means a sign or image s
 					<section>
 						<b><ul>
 							<li>Indicate the type or 'container' of that variable</li>
-							<li>There are three types of sigils:</li>
+							<li>There are three common types of sigils:</li>
 							<ul>
 								<li>$: scalar</li>
 								<li>@: array</li>

--- a/index.html
+++ b/index.html
@@ -528,7 +528,7 @@ ppm> install Capoeira::Musica;
 #debian-based
 apt-get install libcapoeira-roda-perl
 #redhat-based
-yum install perl-capoeira-roda
+yum install perl-Capoeira-Roda
 						</code></pre>
 					</section>
 					<section>


### PR DESCRIPTION
Properly packed RPMs of CPAN modules have upper case letters where they appear in the distribution name.